### PR TITLE
Fix multiple definitions of pxa260Framebuffer

### DIFF
--- a/include/pxa260/pxa260_LCD.h
+++ b/include/pxa260/pxa260_LCD.h
@@ -4,7 +4,7 @@
 #include "pxa260_CPU.h"
 #include "pxa260_IC.h"
 
-uint16_t* pxa260Framebuffer;
+extern uint16_t* pxa260Framebuffer;
 
 /*
 	PXA260 OS LCD controller


### PR DESCRIPTION
Getting redefinition errors on the newer clang in Android NDK r22.